### PR TITLE
Fix for layout issue on width change

### DIFF
--- a/DMInspectorPalette/DMPaletteContainer.h
+++ b/DMInspectorPalette/DMPaletteContainer.h
@@ -31,8 +31,8 @@
 
 #pragma mark - Other Utils
 
-// Relayout items (no animation is provided)
-- (void) layoutSubviews;
+// Relayout items
+- (void) layoutSubviewsAnimated:(BOOL)animated;
 
 @end
 

--- a/DMInspectorPalette/DMPaletteSectionView.h
+++ b/DMInspectorPalette/DMPaletteSectionView.h
@@ -20,7 +20,7 @@ enum  {
     
 }
 
-@property (readonly)            DMPaletteState      state;          // Current state of the section (see DMPaletteState)
+@property (nonatomic,assign)            DMPaletteState      state;          // Current state of the section (see DMPaletteState)
 @property (nonatomic,assign)    NSString*           title;          // Title of the header
 @property (nonatomic,assign)    NSUInteger          index;          // Current element index (assign it then use layoutSubviews to rearrange all the other items)
 @property (strong)              DMPaletteContainer* container;      // Related section's container


### PR DESCRIPTION
This unifies the calculation of the frames for the section views into a single method. Previously the animated method and the layoutSubviews method resulted in different frames causing them to jump when calling layoutSubviews after a collapse, e.g if the frame was changed due to a resize.
