### PR TITLE
Fixed resizing bug

### DIFF
--- a/DMInspectorPalette/DMPaletteContainer.m
+++ b/DMInspectorPalette/DMPaletteContainer.m
@@ -44,6 +44,7 @@
         self.wantsLayer = YES;
         self.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
         contentView = [[DMFlippedClipView alloc] initWithFrame:self.bounds];
+        contentView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
         [self setDocumentView:contentView];
         [self setHasVerticalScroller:YES];
         [self setHasHorizontalScroller:YES];

--- a/DMInspectorPalette/DMPaletteSectionView.m
+++ b/DMInspectorPalette/DMPaletteSectionView.m
@@ -114,10 +114,6 @@
     return YES;
 }
 
-- (void) viewWillMoveToSuperview:(NSView *)newSuperview {
-    
-}
-
 - (NSComparisonResult)compare:(DMPaletteSectionView *)otherView {
     if(otherView.index > index)
         return NSOrderedAscending;


### PR DESCRIPTION
I found that the clip view needed to also have an autoresizing mask because otherwise it would not be properly adjusted when used inside an NSSplitView and in connection with auto layout. This would lead to the palette either being to wide or to narrow. Adding the autoresizing mask fixes it.

![screen shot 2013-10-12 at 6 23 49 pm](https://f.cloud.github.com/assets/333270/1320424/c3e42664-335a-11e3-88f0-1b6d2ec3eec7.png)

I also removed an empty overwritten method. That is bad form.
