### PR TITLE
Fix for width of section views getting out of whack

### DIFF
--- a/DMInspectorPalette/DMPaletteContainer.m
+++ b/DMInspectorPalette/DMPaletteContainer.m
@@ -67,6 +67,7 @@
         paletteSection.index = idx;
         [contentView addSubview:paletteSection];
     }];
+    
     [self layoutSubviewsAnimated:NO];
 }
 
@@ -91,11 +92,22 @@
 	return frame;
 }
 
--(void) layout {
+- (void)_updateContentSizeIfNecessary
+{
+    CGRect boundsForContent = [self boundsForContent];
+    
+    if (!CGRectEqualToRect(boundsForContent, contentView.frame))
+    {
+        [contentView setFrame:boundsForContent];
+    }
+}
+
+- (void)layout
+{
+    // do not update frames of subviews here or else this messes up layout widths using auto layout
+    [self _updateContentSizeIfNecessary];
+    
     [super layout];
-    // Fixes a small  bug in the DMInspectorPalette that was keeping the subviews/DMPaletteSectionViews from resizing when autolayout is used.
-    // Thanks to Owen Hildreth
-    [self layoutSubviewsAnimated:NO];
 }
 
 - (NSRect)frameForSectionAtIndex:(NSUInteger)index
@@ -148,8 +160,8 @@
 		[NSAnimationContext beginGrouping];
     	[[NSAnimationContext currentContext] setDuration:kDMPaletteContainerAnimationDuration];
 		[[NSAnimationContext currentContext] setCompletionHandler:^{
-			NSRect contentRect = [self boundsForContent];
-			[[self documentView] setFrame:contentRect];
+            
+			[self _updateContentSizeIfNecessary];
 		}];
 	}
 	
@@ -174,8 +186,7 @@
 	}
 	else
 	{
-		NSRect contentRect = [self boundsForContent];
-		[[self documentView] setFrame:contentRect];
+		[self _updateContentSizeIfNecessary];
 	}
 }
 


### PR DESCRIPTION
When using auto layout the previous code would have an issue on 10.8 in if the palette was used inside an NSTabView. The subviews using auto layout constraints would not get updated properly.

This fix removes a previous workaround and reduces it to the actually necessary updating of the content view bounds. The subview frames are getting updated by the autoresizing masks or the layout constraints that are getting created from these.
